### PR TITLE
fix(dotnet): support macOS's Bash 3.2 in supports_option()

### DIFF
--- a/dotnet/action.yml
+++ b/dotnet/action.yml
@@ -270,25 +270,26 @@ runs:
       run: |
         echo "::debug::Building argument list..."
 
-        # Define command support maps (cached for performance)
-        declare -A COMMAND_SUPPORT=(
-          ["verbosity"]="build|restore|pack|publish|test|clean|msbuild|workload"
-          ["configuration"]="build|publish|test|pack|run"
-          ["framework"]="build|publish|test|pack|run"
-          ["runtime"]="build|publish|test|pack|run"
-          ["arch"]="build|publish|run"
-          ["output"]="build|publish|pack|run|tool"
-          ["nologo"]="build|restore|pack|publish|test|clean|msbuild|run|add|remove|list"
-          ["no-restore"]="build|test|publish|pack"
-          ["no-build"]="test|publish"
-          ["artifacts-path"]="build|restore|publish|pack|test|clean|run"
-        )
-
-        # Function to check command support
+        # Function to check command support. Uses a case statement rather than an
+        # associative array (`declare -A`) because macOS runners ship Apple's system
+        # Bash 3.2 (frozen pre-GPLv3), which does not support `declare -A` at all.
         supports_option() {
           local option="$1"
           local command="${{ inputs.command }}"
-          echo "$command" | grep -iqE "^(${COMMAND_SUPPORT[$option]})$"
+          local pattern=""
+          case "$option" in
+            verbosity)      pattern="build|restore|pack|publish|test|clean|msbuild|workload" ;;
+            configuration)  pattern="build|publish|test|pack|run" ;;
+            framework)      pattern="build|publish|test|pack|run" ;;
+            runtime)        pattern="build|publish|test|pack|run" ;;
+            arch)           pattern="build|publish|run" ;;
+            output)         pattern="build|publish|pack|run|tool" ;;
+            nologo)         pattern="build|restore|pack|publish|test|clean|msbuild|run|add|remove|list" ;;
+            no-restore)     pattern="build|test|publish|pack" ;;
+            no-build)       pattern="test|publish" ;;
+            artifacts-path) pattern="build|restore|publish|pack|test|clean|run" ;;
+          esac
+          echo "$command" | grep -iqE "^($pattern)$"
         }
 
         # Start building arguments


### PR DESCRIPTION
## Summary

Fixes `dotnet/action.yml`'s argument-builder step so it works on macOS runners.

## Why

`supports_option()` used `declare -A COMMAND_SUPPORT=(...)` (an associative array), which requires Bash 4+. macOS runners (`macos-*`) ship Apple's system Bash 3.2 (frozen pre-GPLv3), where `declare -A` fails outright:

```
declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```

This broke every single command run through this action on a macOS runner - restore, build, everything. `Plugin.Bluetooth`'s `ci.yml` never hit this because its build job runs on `windows-latest`. This surfaced while modernizing `Laerdal.Dfu`'s pipeline onto this shared action, whose build job needs `macos-14` for `net10.0-ios`/`net10.0-maccatalyst` native binding compilation - apparently the first consumer of this action on macOS.

## Fix

Replaced the associative-array lookup with a `case` statement - functionally identical, portable back to Bash 3.2. Verified locally against `/bin/bash --version` 3.2.57 (matching the `macos-14` runner exactly): reproduced the exact failure with the old code, confirmed the new code works.

## Scope

Single file, `dotnet/action.yml`, no input/output/behavior changes for any existing (Linux/Windows) consumer.

## Risk

Low - the case statement encodes the exact same command-to-option mapping as the associative array it replaces.